### PR TITLE
Blocking unencrypted logon attempts

### DIFF
--- a/IPBanService.cs
+++ b/IPBanService.cs
@@ -258,6 +258,8 @@ popd
 
         private void ProcessIPAddress(string ipAddress, XmlDocument doc)
         {
+            Log.Write(LogLevel.Info, "Processing ip: {0}", ipAddress);
+
             if (string.IsNullOrWhiteSpace(ipAddress))
             {
                 return;

--- a/IPBanService.cs
+++ b/IPBanService.cs
@@ -278,47 +278,55 @@ popd
             }
             else
             {
-                lock (ipBlocker)
+                string whiteListReason = config.ReasonIsWhiteListed(doc.OuterXml);
+                if (!string.IsNullOrEmpty(whiteListReason))
                 {
-                    // Get the IPBlockCount, if one exists.
-                    IPBlockCount ipBlockCount;
-                    ipBlocker.TryGetValue(ipAddress, out ipBlockCount);
-                    if (ipBlockCount == null)
+                    Log.Write(LogLevel.Info, "Ignoring whitelisted Reason {0}, user name: {1}", whiteListReason, userName);
+                }
+                else
+                {
+                    lock (ipBlocker)
                     {
-                        // This is the first failed login attempt, so record a new IPBlockCount.
-                        ipBlockCount = new IPBlockCount();
-                        ipBlocker[ipAddress] = ipBlockCount;
-                    }
-
-                    // Increment the count.
-                    ipBlockCount.IncrementCount();
-
-                    Log.Write(LogLevel.Info, "Incrementing count for ip {0} to {1}, user name: {2}", ipAddress, ipBlockCount.Count, userName);
-
-                    // check for the target user name for additional blacklisting checks                    
-                    bool blackListed = config.IsBlackListed(ipAddress) || (userName != null && config.IsBlackListed(userName));
-
-                    // if the ip is black listed or they have reached the maximum failed login attempts before ban, ban them
-                    if (blackListed || ipBlockCount.Count == config.FailedLoginAttemptsBeforeBan)
-                    {
-                        // if they are not black listed OR this is the first increment of a black listed ip address, perform the ban
-                        if (!blackListed || ipBlockCount.Count == 1)
+                        // Get the IPBlockCount, if one exists.
+                        IPBlockCount ipBlockCount;
+                        ipBlocker.TryGetValue(ipAddress, out ipBlockCount);
+                        if (ipBlockCount == null)
                         {
-                            Log.Write(LogLevel.Error, "Banning ip address: {0}, user name: {1}, black listed: {2}, count: {3}", ipAddress, userName, blackListed, ipBlockCount.Count);
-                            ipBlockerDate[ipAddress] = DateTime.UtcNow;
-                            ExecuteBanScript();
+                            // This is the first failed login attempt, so record a new IPBlockCount.
+                            ipBlockCount = new IPBlockCount();
+                            ipBlocker[ipAddress] = ipBlockCount;
                         }
-                        else
-                        {
-                            Log.Write(LogLevel.Info, "Ignoring previously banned black listed ip {0}, user name: {1}, ip should already be banned", ipAddress, userName);
-                        }
-                    }
-                    else if (ipBlockCount.Count > config.FailedLoginAttemptsBeforeBan)
-                    {
-                        Log.Write(LogLevel.Info, "Got event with ip address {0}, count {1}, ip should already banned", ipAddress, ipBlockCount.Count);
-                    }
 
-                    LogInitialConfig();
+                        // Increment the count.
+                        ipBlockCount.IncrementCount();
+
+                        Log.Write(LogLevel.Info, "Incrementing count for ip {0} to {1}, user name: {2}", ipAddress, ipBlockCount.Count, userName);
+
+                        // check for the target user name for additional blacklisting checks                    
+                        bool blackListed = config.IsBlackListed(ipAddress) || (userName != null && config.IsBlackListed(userName));
+
+                        // if the ip is black listed or they have reached the maximum failed login attempts before ban, ban them
+                        if (blackListed || ipBlockCount.Count == config.FailedLoginAttemptsBeforeBan)
+                        {
+                            // if they are not black listed OR this is the first increment of a black listed ip address, perform the ban
+                            if (!blackListed || ipBlockCount.Count == 1)
+                            {
+                                Log.Write(LogLevel.Error, "Banning ip address: {0}, user name: {1}, black listed: {2}, count: {3}", ipAddress, userName, blackListed, ipBlockCount.Count);
+                                ipBlockerDate[ipAddress] = DateTime.UtcNow;
+                                ExecuteBanScript();
+                            }
+                            else
+                            {
+                                Log.Write(LogLevel.Info, "Ignoring previously banned black listed ip {0}, user name: {1}, ip should already be banned", ipAddress, userName);
+                            }
+                        }
+                        else if (ipBlockCount.Count > config.FailedLoginAttemptsBeforeBan)
+                        {
+                            Log.Write(LogLevel.Info, "Got event with ip address {0}, count {1}, ip should already banned", ipAddress, ipBlockCount.Count);
+                        }
+
+                        LogInitialConfig();
+                    }
                 }
             }
         }

--- a/app.config
+++ b/app.config
@@ -159,6 +159,9 @@
     <!-- Comma separated list of ip addresses OR DNS names that are never banned -->
     <add key="Whitelist" value="127.0.0.1,::1,0.0.0.0,-" />
 
+    <!-- When sql server certificate is updated, existing sql connections fail -->
+    <add key="WhitelistReason" value="Reason: Access to server validation failed while revalidating the login on the connection." />
+
     <!--
       Regular expression for more advanced whitelisting. Shortcut: use * to allow any piece of an ip (i.e. 128.128.128.*).
       Sample regex that whitelists a few ips: ^(128\.128\.128\.*)|(99\.99\.99\.[0-9])$

--- a/app.config
+++ b/app.config
@@ -50,6 +50,26 @@
         </Expressions>
       </Group>
 
+      <!-- This group will block audit failures from failed login attempts to Microsoft SQL Server - Uncomment if your server requires encryption ("Encryption is required to connect to this server but the client library does not support encryption; the connection has been closed. Please upgrade your client library.") -->
+      <!--<Group>
+        <Keywords>0x80000000000000</Keywords>
+        <Path>Application</Path>
+        <Expressions>
+          <Expression>
+            <XPath>//Provider[@Name='MSSQLSERVER']</XPath>
+            <Regex></Regex>
+          </Expression>
+          <Expression>
+            <XPath>//Data</XPath>
+            <Regex>
+              <![CDATA[
+              \[Client: ?(?<ipaddress>.*?)\]
+            ]]>
+            </Regex>
+          </Expression>
+        </Expressions>
+      </Group>-->
+
       <!-- This group will block audit failures from failed login attempts to MySQL Server -->
       <Group>
         <Keywords>0x80000000000000</Keywords>


### PR DESCRIPTION
I'm getting a lot of these unencrypted logon attempts.
First I wondered why IP-Ban didn't block them, so I added more logging.
After I understood why they were not blocked I added a new ExpressionsToBlockGroup to the config.
